### PR TITLE
Sros harden api

### DIFF
--- a/clients/rospy/src/rospy/impl/tcpros_pubsub.py
+++ b/clients/rospy/src/rospy/impl/tcpros_pubsub.py
@@ -328,12 +328,13 @@ class TCPROSHandler(rospy.impl.transport.ProtocolHandler):
         for required in ['topic', 'md5sum', 'callerid']:
             if not required in header:
                 return "Missing required '%s' field"%required
-        transport_policy = security.get().policy.transport
-        if transport_policy:
-            if not transport_policy.accept_topic(sock, header['topic']):
-                return "Subscriber policy violation"
         else:
             resolved_topic_name = header['topic']
+            transport_policy = security.get().policy.transport
+            if transport_policy:
+                if not transport_policy.accept_topic(sock, resolved_topic_name):
+                    return "Subscriber policy violation"
+
             md5sum = header['md5sum']
             tm = rospy.impl.registration.get_topic_manager()
             topic = tm.get_publisher_impl(resolved_topic_name)

--- a/clients/rospy/src/rospy/impl/tcpros_service.py
+++ b/clients/rospy/src/rospy/impl/tcpros_service.py
@@ -226,13 +226,14 @@ def service_connection_handler(sock, client_addr, header):
         if not required in header:
             return "Missing required '%s' field"%required
 
-    transport_policy = security.get().policy.transport
-    if transport_policy:
-        if not transport_policy.accept_service(sock, header['service']):
-            return "Client policy violation"
     else:
-        logger.debug("connection from %s:%s", client_addr[0], client_addr[1])
         service_name = header['service']
+        transport_policy = security.get().policy.transport
+        if transport_policy:
+            if not transport_policy.accept_service(sock, service_name):
+                return "Client policy violation"
+
+        logger.debug("connection from %s:%s", client_addr[0], client_addr[1])
         
         #TODO: make service manager configurable. I think the right
         #thing to do is to make these singletons private members of a

--- a/clients/rospy/src/rospy/impl/tcpros_service.py
+++ b/clients/rospy/src/rospy/impl/tcpros_service.py
@@ -226,8 +226,10 @@ def service_connection_handler(sock, client_addr, header):
         if not required in header:
             return "Missing required '%s' field"%required
 
-    if not security.get().policy.allow_service_connection(sock, client_addr, header):
-        return "Client policy violation"
+    transport_policy = security.get().policy.transport
+    if transport_policy:
+        if not transport_policy.accept_service(sock, header['service']):
+            return "Client policy violation"
     else:
         logger.debug("connection from %s:%s", client_addr[0], client_addr[1])
         service_name = header['service']
@@ -506,8 +508,10 @@ class ServiceProxy(_Service):
             transport.buff_size = self.buff_size
             try:
                 transport.connect(dest_addr, dest_port, service_uri)
-                if not security.get().policy.allow_call(transport.socket, dest_addr, dest_port, self.resolved_name):
-                    raise rospy.exceptions.TransportInitError("Server policy violation")
+                transport_policy = security.get().policy.transport
+                if transport_policy:
+                    if not transport_policy.connect_service(transport.socket, self.resolved_name):
+                        raise rospy.exceptions.TransportInitError("Server policy violation")
             except TransportInitError as e:
                 # can be a connection or md5sum mismatch
                 raise ServiceException("unable to connect to service: %s"%e)

--- a/tools/rosgraph/src/rosgraph/keyserver.py
+++ b/tools/rosgraph/src/rosgraph/keyserver.py
@@ -80,7 +80,10 @@ class Keyserver(object):
     def init_context(self):
         capath = os.path.join(self.keystore_path, 'capath')
         certfile, keyfile = self.key_helper.init_keyserver()
-        password = os.environ['SROS_KEYSERVER_PASSWORD']
+        if 'SROS_KEYSERVER_PASSWORD' in os.environ:
+            password = os.environ['SROS_KEYSERVER_PASSWORD']
+        else:
+            password = None
         self.context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
         self.context.verify_mode = getattr(ssl, self.keyserver_mode)
         self.context.load_verify_locations(capath=capath)

--- a/tools/rosgraph/src/rosgraph/policy.py
+++ b/tools/rosgraph/src/rosgraph/policy.py
@@ -19,8 +19,13 @@ _logger = logging.getLogger('rosgraph.policy')
 
 class Policy(object):
     # TODO: add security logging stuff here
-    def __init__(self):
+    def __init__(self, node_id, node_stem, node_name):
         _logger.info("policy init")
+
+        self.node_id = node_id
+        self.node_stem = node_stem
+        self.node_name = node_name
+
         self.engine = None
         self.master_api = None
         self.slave_api = None
@@ -29,8 +34,8 @@ class Policy(object):
 #########################################################################
 
 class NoPolicy(Policy):
-    def __init__(self):
-        super(NoPolicy, self).__init__()
+    def __init__(self, node_id, node_stem, node_name):
+        super(NoPolicy, self).__init__(node_id, node_stem, node_name)
         _logger.info("  rospy.policy.NoPolicy init")
 
 ##########################################################################
@@ -38,18 +43,16 @@ class NoPolicy(Policy):
 class NameSpacePolicy(Policy):
 
     def __init__(self, node_id, node_stem, node_name):
-        self.node_id = node_id
-        self.node_stem = node_stem
-        self.node_name = node_name
-        super(NameSpacePolicy, self).__init__()
+        super(NameSpacePolicy, self).__init__(node_id, node_stem, node_name)
         _logger.info("rospy.policy.NameSpacePolicy init")
 
         self.engine = NameSpaceEngine(self.node_name, _logger)
         self.master_api = NameSpaceMasterAPI(self.engine, _logger)
         # self.master_api = None
-        # self.slave_api = NameSpaceSlaveAPI(self.engine, _logger)
-        self.slave_api = None
+        self.slave_api = NameSpaceSlaveAPI(self.engine, _logger)
+        # self.slave_api = None
         self.transport = NameSpaceTransport(self.engine, _logger)
+        # self.transport = None
 
 #########################################################################
 _policy = None
@@ -64,11 +67,11 @@ def init(node_id, node_stem, node_name):
             if os.environ['SROS_POLICY'] == 'namespace':
                 _policy = NameSpacePolicy(node_id, node_stem, node_name)
             elif os.environ['SROS_POLICY'] == 'none':
-                _policy = NoPolicy()
+                _policy = NoPolicy(node_id, node_stem, node_name)
             else:
                 raise ValueError("illegal SROS_POLICY value: [%s]" % os.environ['SROS_POLICY'])
         else:
-            _policy = NoPolicy()
+            _policy = NoPolicy(node_id, node_stem, node_name)
 
 
 def get():

--- a/tools/rosgraph/src/rosgraph/policy.py
+++ b/tools/rosgraph/src/rosgraph/policy.py
@@ -5,30 +5,13 @@ import os
 # import names
 # import time
 # import socket
-import traceback
 # import ssl
-import rosgraph_helper
 
-import json
-from copy import deepcopy
-from sros_consts import ROLE_STRUCT, EXTENSION_MAPPING
-
-from cryptography import hazmat, x509
-from cryptography.x509.oid import NameOID
-from cryptography.hazmat.backends import default_backend
-
-from apparmor.aare import re
-from apparmor.common import convert_regexp
-
-class GraphModes:
-    audit = 'audit'
-    complain = 'complain'
-    enforce = 'enforce'
-    train = 'train'
-
-    class __metaclass__(type):
-        def __contains__(self, item):
-            return hasattr(self, item)
+from validators import \
+    NameSpaceEngine, \
+    NameSpaceMasterAPI, \
+    NameSpaceSlaveAPI, \
+    NameSpaceTransport
 
 _logger = logging.getLogger('rosgraph.policy')
 
@@ -38,37 +21,10 @@ class Policy(object):
     # TODO: add security logging stuff here
     def __init__(self):
         _logger.info("policy init")
-
-    def allow_registerPublisher(self, caller_id, topic):
-        print('Policy.allow_registerPublisher()')
-        return True
-
-    def allow_registerSubscriber(self, caller_id, topic):
-        print('Policy.allow_registerSubscriber()')
-        return True
-
-    def allow_registerService(self, caller_id, service):
-        print('Policy.allow_registerService()')
-        return True
-
-    def allow_lookupService(self, caller_id, service):
-        print('Policy.allow_lookupService()')
-        return True
-
-    def allow_xmlrpc_request(self, cert_text, cert_binary):
-        return True
-
-    def allow_connect_subscriber(self, sock, dest_addr, dest_port, pub_uri, receive_cb, resolved_topic_name):
-        return True
-
-    def allow_topic_connection(self, sock, client_addr, header):
-        return True
-
-    def allow_call(self, sock, dest_addr, dest_port, service_uri):
-        return True
-
-    def allow_service_connection(self, sock, client_addr, header):
-        return True
+        self.engine = None
+        self.master_api = None
+        self.slave_api = None
+        self.transport = None
 
 #########################################################################
 
@@ -81,19 +37,6 @@ class NoPolicy(Policy):
 
 class NameSpacePolicy(Policy):
 
-    def init_graph(self):
-        # ugly... need to figure out a graceful way to pass the graph
-        self.graph_mode = None
-        if 'SROS_POLICY_MODE' in os.environ:
-            graph_mode = os.environ['SROS_POLICY_MODE']
-            self.graph_mode = getattr(GraphModes, graph_mode, GraphModes.enforce)
-
-        if self.node_name == 'master':
-            self.graph = rosgraph_helper.GraphStructure()
-            if 'SROS_POLICY_CONFIG' in os.environ:
-                self.graph.graph_path = os.environ['SROS_POLICY_CONFIG']
-                self.graph.load_graph()
-
     def __init__(self, node_id, node_stem, node_name):
         self.node_id = node_id
         self.node_stem = node_stem
@@ -101,173 +44,12 @@ class NameSpacePolicy(Policy):
         super(NameSpacePolicy, self).__init__()
         _logger.info("rospy.policy.NameSpacePolicy init")
 
-        self.init_graph()
-
-    def log_register(self, enable, flag, info):
-        if enable:
-            _logger.info("{}REG [{}]:{} {} to graph:[{}]".format(flag, *info))
-
-    def allow_register(self, caller_id, role_name, action_name, mask):
-        # TODO fix crazy imports
-        from security import caller_id_to_node_stem
-        
-        node_stem = caller_id_to_node_stem(caller_id)
-        info = (action_name, mask, self.node_stem, self.graph.graph_path)
-        if self.graph_mode is GraphModes.enforce:
-            allowed, audit = self.graph.is_allowed(node_stem, role_name, action_name, mask)
-            flag = '*' if allowed else '!'
-            self.log_register(audit, flag, info)
-            return allowed
-        elif self.graph_mode is GraphModes.train:
-            if self.graph.graph_path is not None:
-                allowed, audit = self.graph.is_allowed(node_stem, role_name, action_name, mask)
-                if not allowed:
-                    self.graph.add_allowed(node_stem, role_name, action_name, mask)
-                    self.graph.save_graph()
-                flag = '*' if allowed else '+'
-                self.log_register((audit or not allowed), flag, info)
-            return True
-        elif self.graph_mode is GraphModes.complain:
-            if self.graph.graph is not None:
-                allowed, audit = self.graph.is_allowed(node_stem, role_name, action_name, mask)
-                flag = '*' if allowed else '!'
-                self.log_register((audit or not allowed), flag, info)
-            else:
-                self.log_register(True, '!', info)
-            return True
-        elif self.graph_mode is GraphModes.audit:
-            if self.graph.graph is not None:
-                allowed, audit = self.graph.is_allowed(node_stem, role_name, action_name, mask)
-                flag = '*' if allowed else '!'
-                self.log_register(True, flag, info)
-                return allowed
-            else:
-                self.log_register(True, '', info)
-                return True
-        else:
-            return False
-
-    def allow_registerPublisher(self, caller_id, topic):
-        if self.graph_mode is None:
-            return True
-        else:
-            role_name = 'topics'
-            mask = ROLE_STRUCT[role_name]['publisher']['mask']
-            return self.allow_register(caller_id, role_name, topic, mask)
-            
-    def allow_registerSubscriber(self, caller_id, topic):
-        if self.graph_mode is None:
-            return True
-        else:
-            role_name = 'topics'
-            mask = ROLE_STRUCT[role_name]['subscriber']['mask']
-            return self.allow_register(caller_id, role_name, topic, mask)
-
-    def allow_registerService(self, caller_id, service):
-        if self.graph_mode is None:
-            return True
-        else:
-            role_name = 'services'
-            mask = ROLE_STRUCT[role_name]['server']['mask']
-            return self.allow_register(caller_id, role_name, service, mask)
-
-    def allow_lookupService(self, caller_id, service):
-        if self.graph_mode is None:
-            return True
-        else:
-            role_name = 'services'
-            mask = ROLE_STRUCT[role_name]['client']['mask']
-            return self.allow_register(caller_id, role_name, service, mask)
-
-    def allow_action(self, allowed, role=None, action=None):
-        # info = (action, mask, self.node_stem, self.graph.graph_path)
-        if self.graph_mode is GraphModes.enforce:
-            # pass the judgment through
-            return allowed
-        elif self.graph_mode is GraphModes.train:
-            # log any violation but let them slide
-            return True
-        elif self.graph_mode is GraphModes.complain:
-            # pass the judgment through but log violations
-            return allowed
-        elif self.graph_mode is GraphModes.audit:
-            # pass the judgment through but log everything
-            return allowed
-        else:
-            return False
-
-    def allow_policies(self, role, action):
-
-        if 'policy_qualifiers' in role['deny']:
-            for qualifiers in role['deny']['policy_qualifiers']:
-                action_regex = re.compile(convert_regexp(qualifiers))
-                if action_regex.search(action):
-                    return False
-
-        if 'policy_qualifiers' in role['allow']:
-            for qualifiers in role['allow']['policy_qualifiers']:
-                action_regex = re.compile(convert_regexp(qualifiers))
-                if action_regex.search(action):
-                    return True
-
-        return False
-
-    def extract_policies(self, cert, role):
-        certificate_policies = cert.extensions.get_extension_for_class(x509.CertificatePolicies)
-        for policy_information in certificate_policies.value:
-            for mode in ['allow', 'deny']:
-                if role[mode]['OID'] == policy_information.policy_identifier.dotted_string:
-                    role[mode]['policy_qualifiers'] = policy_information.policy_qualifiers
-
-    def extract_cert(self, sock):
-        cert_binary = sock.getpeercert(binary_form=True)
-        cert = x509.load_der_x509_certificate(cert_binary, default_backend())
-        return cert
-
-    def allow_connect_subscriber(self, sock, dest_addr, dest_port, pub_uri, receive_cb, resolved_topic_name):
-        cert = self.extract_cert(sock)
-        role = deepcopy(ROLE_STRUCT['topics']['publisher'])
-        self.extract_policies(cert, role)
-        allowed = self.allow_policies(role, resolved_topic_name)
-        print('##################################################')
-        print("role:\n",json.dumps(role, sort_keys=True, indent=4))
-        print('Callback: {}\n action: {}\n allowed: {}'.format('allow_connect_subscriber', resolved_topic_name, allowed))
-        print('##################################################')
-        return self.allow_action(allowed)
-
-    def allow_topic_connection(self, sock, client_addr, header):
-        cert = self.extract_cert(sock)
-        role = deepcopy(ROLE_STRUCT['topics']['subscriber'])
-        self.extract_policies(cert, role)
-        allowed = self.allow_policies(role, header['topic'])
-        print('##################################################')
-        print("role:\n",json.dumps(role, sort_keys=True, indent=4))
-        print('Callback: {}\n action: {}\n allowed: {}'.format('allow_topic_connection', header['topic'], allowed))
-        print('##################################################')
-        return self.allow_action(allowed)
-
-    def allow_call(self, sock, dest_addr, dest_port, resolved_name):
-        cert = self.extract_cert(sock)
-        role = deepcopy(ROLE_STRUCT['services']['server'])
-        self.extract_policies(cert, role)
-        allowed = self.allow_policies(role, resolved_name)
-        print('##################################################')
-        print("role:\n",json.dumps(role, sort_keys=True, indent=4))
-        print('Callback: {}\n action: {}\n allowed: {}'.format('allow_call', resolved_name, allowed))
-        print('##################################################')
-        return self.allow_action(allowed)
-
-    def allow_service_connection(self, sock, client_addr, header):
-        cert = self.extract_cert(sock)
-        role = deepcopy(ROLE_STRUCT['services']['client'])
-        self.extract_policies(cert, role)
-        allowed = self.allow_policies(role, header['service'])
-        print('##################################################')
-        print("role:\n",json.dumps(role, sort_keys=True, indent=4))
-        print('Callback: {}\n action: {}\n allowed: {}'.format('allow_service_connection', header['service'], allowed))
-        print('##################################################')
-        return self.allow_action(allowed)
-
+        self.engine = NameSpaceEngine(self.node_name, _logger)
+        # self.master_api = NameSpaceMasterAPI(self.engine, _logger)
+        self.master_api = None
+        # self.slave_api = NameSpaceSlaveAPI(self.engine, _logger)
+        self.slave_api = None
+        self.transport = NameSpaceTransport(self.engine, _logger)
 
 #########################################################################
 _policy = None

--- a/tools/rosgraph/src/rosgraph/policy.py
+++ b/tools/rosgraph/src/rosgraph/policy.py
@@ -45,8 +45,8 @@ class NameSpacePolicy(Policy):
         _logger.info("rospy.policy.NameSpacePolicy init")
 
         self.engine = NameSpaceEngine(self.node_name, _logger)
-        # self.master_api = NameSpaceMasterAPI(self.engine, _logger)
-        self.master_api = None
+        self.master_api = NameSpaceMasterAPI(self.engine, _logger)
+        # self.master_api = None
         # self.slave_api = NameSpaceSlaveAPI(self.engine, _logger)
         self.slave_api = None
         self.transport = NameSpaceTransport(self.engine, _logger)

--- a/tools/rosgraph/src/rosgraph/security.py
+++ b/tools/rosgraph/src/rosgraph/security.py
@@ -270,7 +270,7 @@ def init(caller_id):
             else:
                 raise ValueError("illegal SROS_SECURITY value: [%s]" % os.environ['SROS_SECURITY'])
         else:
-            _security = NoSecurity()
+            _security = NoSecurity(caller_id)
 
 def get():
     if _security is None:

--- a/tools/rosgraph/src/rosgraph/security.py
+++ b/tools/rosgraph/src/rosgraph/security.py
@@ -55,7 +55,7 @@ class NoSecurity(Security):
         from policy import NoPolicy
         self.policy = NoPolicy()
 
-    def xmlrpcapi(self, uri, node_name = None):
+    def xmlrpcapi(self, uri, context=None):
         uriValidate = urlparse.urlparse(uri)
         if not uriValidate[0] or not uriValidate[1]:
             return None

--- a/tools/rosgraph/src/rosgraph/security.py
+++ b/tools/rosgraph/src/rosgraph/security.py
@@ -41,6 +41,8 @@ class Security(object):
         return sock
     def xmlrpc_protocol(self):
         return 'http'
+    def get_context(self, sock):
+        return None
 
 #########################################################################
 
@@ -75,7 +77,7 @@ class NoSecurity(Security):
 
     def accept(self, server_sock, server_node_name):
         s = server_sock.accept()
-        return (s[0], s[1], 'unknown')
+        return (s[0], s[1])
 
 #########################################################################
 
@@ -244,91 +246,15 @@ class TLSSecurity(Security):
         client_stream = None
         try:
             client_stream = self.context.wrap_socket(client_sock, server_side=True)
-            client_cert = client_stream.getpeercert()
-            # print("SSLSecurity.accept(server_node_name=%s) getpeercert = %s" % (server_node_name, repr(client_cert)))
-            # cn = cert_cn(client_cert)
-            # if cn is None:
-            #     raise Exception("unknown certificate format")
-            # if not cn.endswith('.client'):
-            #     raise Exception("unexpected commonName format: %s" % cn)
-            # # get rid of the '.client' suffix
-            # cn = '.'.join(cn.split('.')[0:-1])
-            # if not cn in self.allowed_clients:
-            #     raise Exception("unknown client [%s] is trying to connect!" % cn)
+            # client_cert = client_stream.getpeercert()
         except Exception as e:
             print("SSLSecurity.accept() wrap_socket exception: %s" % e)
             raise
         return (client_stream, client_addr)
-
-
-    # def allow_xmlrpc_request(self, cert_text, cert_binary):
-    #     cn = cert_cn(cert_text)
-    #     if cn is None:
-    #         return None
-    #     # print("allow_xmlrpc_request() node=%s commonName=%s" % (self.node_stem, cn))
-    #     # sanity-check to ensure that it ends in '.client'
-    #     if not cn.endswith('.client'):
-    #         return None
-    #     try:
-    #         # if we're master, make sure this cert exists in our keystore
-    #         if self.node_stem == 'master':  # NOW I AM THE MASTER
-    #             path = os.path.join(self.keystore, cn + '.cert')
-    #             if '..' in path:
-    #                 print('HEY WHAT ARE YOU TRYING TO DO WITH THOSE DOTS')
-    #                 return None
-    #             # print('looking for client cert in [%s]' % path)
-    #             if not os.path.isfile(path):
-    #                 print("WOAH THERE PARTNER. I DON'T KNOW [%s]" % cn)
-    #                 return None
-    #             with open(path, 'r') as client_cert_file:
-    #                 file_contents = client_cert_file.read()
-    #                 # remove header and footer lines
-    #                 file_contents = ''.join(file_contents.split('\n')[1:-2])
-    #             # print('file contents: %s' % file_contents)
-    #             client_cert = base64.b64encode(cert_binary)
-    #             # print('cert transmitted: %s' % client_cert)
-    #             if file_contents != client_cert:
-    #                 print('WOAH. cert mismatch!')
-    #                 return None
-    #             else:
-    #                 # print('    cert matches OK')
-    #                 return cn[:-7]
-    #         else:  # we're not the master. life is more complicated.
-    #             # see if it's the master
-    #             if cn == 'master.client':
-    #                 # we have this one in our keystore; we can verify it
-    #                 cert_path = os.path.join(self.keystore, 'master.client.cert')
-    #                 with open(cert_path, 'r') as cert_file:
-    #                     saved_cert = cert_file.read()
-    #                     # remove header and footer lines
-    #                     saved_cert = ''.join(saved_cert.split('\n')[1:-2])
-    #                 presented_cert = base64.b64encode(cert_binary)
-    #                 if saved_cert != presented_cert:
-    #                     print("WOAH. master client certificate mismatch!")
-    #                     return None
-    #                 else:
-    #                     # print("   master client cert matches OK")
-    #                     return 'master'
-    #             # see if we are talking to ourselves
-    #             cn_without_suffix = '.'.join(cn.split('.')[0:-1])
-    #             if cn_without_suffix == self.node_stem:
-    #                 # print("    I'm talking to myself again.")
-    #                 return cn_without_suffix  # it's always healthy to talk to yourself
-    #             if cn_without_suffix in self.allowed_clients:
-    #                 # print("    client %s is OK; it's in %s's allowed_clients list: %s" % (cn_without_suffix, self.node_stem, repr(self.allowed_clients)))
-    #                 return cn_without_suffix
-    #             else:
-    #                 print(
-    #                     "    client %s xmlrpc connection denied; it's not in %s's allowed list of clients: %s" % (
-    #                     cn_without_suffix, self.node_stem, repr(self.allowed_clients)))
-    #                 return None
-    #
-    #     except Exception as e:
-    #         print('oh noes: %s' % e)
-    #         return None
-    #     print("WOAH WOAH WOAH how did i get here?")
-    #     return 'ahhhhhhhhhhhh'
-
+    
+    def get_context(self, sock):
+        cert = sock.getpeercert(binary_form=True)
+        return cert
 
 #########################################################################
 _security = None

--- a/tools/rosgraph/src/rosgraph/sros_consts.py
+++ b/tools/rosgraph/src/rosgraph/sros_consts.py
@@ -48,3 +48,14 @@ EXTENSION_MAPPING = {
     'key': '.pem',
     'cert': '.cert',
 }
+
+
+class GraphModes:
+    audit = 'audit'
+    complain = 'complain'
+    enforce = 'enforce'
+    train = 'train'
+
+    class __metaclass__(type):
+        def __contains__(self, item):
+            return hasattr(self, item)

--- a/tools/rosgraph/src/rosgraph/validators.py
+++ b/tools/rosgraph/src/rosgraph/validators.py
@@ -1,0 +1,264 @@
+from __future__ import print_function
+
+import logging
+import os
+# import names
+# import time
+# import socket
+import traceback
+# import ssl
+import rosgraph_helper
+
+import json
+from copy import deepcopy
+from sros_consts import ROLE_STRUCT, GraphModes
+
+from cryptography import hazmat, x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.backends import default_backend
+
+from apparmor.aare import re
+from apparmor.common import convert_regexp
+
+
+class PolicyInvalid(Exception):
+    """Exception that is raised when a policy fails validation checks"""
+
+    def __init__(self, message):
+        self._message = message
+
+    def __str__(self):
+        return str(self._message)
+
+
+class NameSpaceEngine(object):
+    def __init__(self, node_name, _logger):
+        self.node_name = node_name
+        self._logger = _logger
+        self._init_graph()
+
+    def _init_graph(self):
+        # ugly... need to figure out a graceful way to pass the graph
+        self.graph_mode = GraphModes.enforce
+        if 'SROS_POLICY_MODE' in os.environ:
+            graph_mode = os.environ['SROS_POLICY_MODE']
+            self.graph_mode = getattr(GraphModes, graph_mode, GraphModes.enforce)
+
+        if self.node_name == 'master':
+            self.graph = rosgraph_helper.GraphStructure()
+            if 'SROS_POLICY_CONFIG' in os.environ:
+                self.graph.graph_path = os.environ['SROS_POLICY_CONFIG']
+                self.graph.load_graph()
+
+    def _log_register(self, enable, flag, info):
+        if enable:
+            self._logger.info("{}REG [{}]:{} {} to graph:[{}]".format(flag, *info))
+
+    def _is_profile_allowed(self, permitted, mode_name, role_name, action_name, caller_id):
+        
+        if permitted:
+            return True
+        else:
+            # TODO fix crazy imports
+            from security import caller_id_to_node_stem
+            node_stem = caller_id_to_node_stem(caller_id)
+            mask = ROLE_STRUCT[mode_name][role_name]['mask']
+            info = (action_name, mask, self.node_stem, self.graph.graph_path)
+            if self.graph_mode is GraphModes.enforce:
+                allowed, audit = self.graph.is_allowed(node_stem, role_name, action_name, mask)
+                flag = '*' if allowed else '!'
+                self.log_register(audit, flag, info)
+                return allowed
+            elif self.graph_mode is GraphModes.train:
+                if self.graph.graph_path is not None:
+                    allowed, audit = self.graph.is_allowed(node_stem, role_name, action_name, mask)
+                    if not allowed:
+                        self.graph.add_allowed(node_stem, role_name, action_name, mask)
+                        self.graph.save_graph()
+                    flag = '*' if allowed else '+'
+                    self.log_register((audit or not allowed), flag, info)
+                return True
+            elif self.graph_mode is GraphModes.complain:
+                if self.graph.graph is not None:
+                    allowed, audit = self.graph.is_allowed(node_stem, role_name, action_name, mask)
+                    flag = '*' if allowed else '!'
+                    self.log_register((audit or not allowed), flag, info)
+                else:
+                    self.log_register(True, '!', info)
+                return True
+            elif self.graph_mode is GraphModes.audit:
+                if self.graph.graph is not None:
+                    allowed, audit = self.graph.is_allowed(node_stem, role_name, action_name, mask)
+                    flag = '*' if allowed else '!'
+                    self.log_register(True, flag, info)
+                    return allowed
+                else:
+                    self.log_register(True, '', info)
+                    return True
+            else:
+                return False
+
+    def _is_action_allowed(self, permitted, mode=None, role=None, action=None):
+        # info = (action, mask, self.node_stem, self.graph.graph_path)
+        if self.graph_mode is GraphModes.enforce:
+            # pass the judgment through
+            return permitted
+        elif self.graph_mode is GraphModes.train:
+            # log any violation but let them slide
+            return True
+        elif self.graph_mode is GraphModes.complain:
+            # pass the judgment through but log violations
+            return permitted
+        elif self.graph_mode is GraphModes.audit:
+            # pass the judgment through but log everything
+            return permitted
+        else:
+            return False
+
+    def _is_policy_permited(self, policy, action):
+        if 'policy_qualifiers' in policy['deny']:
+            for qualifiers in policy['deny']['policy_qualifiers']:
+                action_regex = re.compile(convert_regexp(qualifiers))
+                if action_regex.search(action):
+                    return False
+
+        if 'policy_qualifiers' in policy['allow']:
+            for qualifiers in policy['allow']['policy_qualifiers']:
+                action_regex = re.compile(convert_regexp(qualifiers))
+                if action_regex.search(action):
+                    return True
+
+        return False
+
+    def _extract_policy(slef, cert, mode_name, role_name):
+        policy = deepcopy(ROLE_STRUCT[mode_name][role_name])
+        certificate_policies = cert.extensions.get_extension_for_class(x509.CertificatePolicies)
+        for policy_information in certificate_policies.value:
+            for mode in ['allow', 'deny']:
+                if policy[mode]['OID'] == policy_information.policy_identifier.dotted_string:
+                    policy[mode]['policy_qualifiers'] = policy_information.policy_qualifiers
+        return policy
+
+    def _extract_cert_from_sock(self, sock):
+        cert_binary = sock.getpeercert(binary_form=True)
+        cert = x509.load_der_x509_certificate(cert_binary, default_backend())
+        return cert
+    
+    def _extract_cert_from_context(self, context):
+        cert = x509.load_der_x509_certificate(context, default_backend())
+        return cert
+
+    def check_policy(self, sock, mode_name, role_name, action_name):
+        cert = self._extract_cert_from_sock(sock)
+        policy = self._extract_policy(cert, mode_name, role_name)
+        permitted = self._is_policy_permited(policy, action_name)
+        allowed = self._is_action_allowed(permitted)
+        return policy, allowed
+
+    def check_profile(self, context, mode_name, role_name, action_name, caller_id):
+        cert = self._extract_cert_from_context(context)
+        policy = self._extract_policy(cert, mode_name, role_name)
+        permitted = self._is_policy_permited(policy, action_name)
+        allowed = self._is_profile_allowed(permitted, mode_name, role_name, action_name, caller_id)
+        return policy, allowed
+
+
+class NameSpaceMasterAPI(object):
+    
+    def __init__(self, engine, _logger):
+        self.engine = engine
+        self._logger = _logger
+    
+    def registerSubscriber(self, context, f):
+        def check_permitted(instance, caller_id, topic, topic_type, caller_api):
+            policy, allowed = self.engine.check_profile(context, 'topics', 'subscriber', topic, caller_id)
+            if allowed:
+                return f(instance, caller_id, topic, topic_type, caller_api)
+            else:
+                raise PolicyInvalid("ERROR: policy invalid for given action")
+        return check_permitted
+    
+    def registerPublisher(self, context, f):
+        def check_permitted(instance, caller_id, topic, topic_type, caller_api):
+            policy, allowed = self.engine.check_profile(context, 'topics', 'publisher', topic, caller_id)
+            if allowed:
+                return f(instance, caller_id, topic, topic_type, caller_api)
+            else:
+                raise PolicyInvalid("ERROR: policy invalid for given action")
+        return check_permitted
+    
+    def registerService(self, context, f):
+        def check_permitted(instance, caller_id, service, service_api, caller_api):
+            policy, allowed = self.engine.check_profile(context, 'topics', 'subscriber', service, caller_id)
+            if allowed:
+                return f(instance, caller_id, service, service_api, caller_api)
+            else:
+                raise PolicyInvalid("ERROR: policy invalid for given action")
+        return check_permitted
+
+    def lookupService(self, context, f):
+        def check_permitted(instance, caller_id, service):
+            policy, allowed = self.engine.check_profile(context, 'topics', 'subscriber', service, caller_id)
+            if allowed:
+                return f(instance, caller_id, service)
+            else:
+                raise PolicyInvalid("ERROR: policy invalid for given action")
+        return check_permitted
+
+
+class NameSpaceSlaveAPI(object):
+    def __init__(self, engine, _logger):
+        self.engine = engine
+        self._logger = _logger
+
+
+class Transport(object):
+
+    def connect_topic(self, sock, topic):
+        return True
+
+    def accept_topic(self, sock, topic):
+        return True
+
+    def connect_service(self, sock, service):
+        return True
+
+    def accept_service(self, sock, service):
+        return True
+
+class NameSpaceTransport(Transport):
+    def __init__(self, engine, _logger):
+        self.engine = engine
+        self._logger = _logger
+    
+    def connect_topic(self, sock, topic):
+        policy, allowed = self.engine.check_policy(sock, 'topics', 'publisher', topic)
+        print('##################################################')
+        print("policy:\n",json.dumps(policy, sort_keys=True, indent=4))
+        print('Callback: {}\n action: {}\n allowed: {}'.format('connect_topic', topic, allowed))
+        print('##################################################')
+        return allowed
+
+    def accept_topic(self, sock, topic):
+        policy, allowed = self.engine.check_policy(sock, 'topics', 'subscriber', topic)
+        print('##################################################')
+        print("policy:\n",json.dumps(policy, sort_keys=True, indent=4))
+        print('Callback: {}\n action: {}\n allowed: {}'.format('accept_topic', topic, allowed))
+        print('##################################################')
+        return allowed
+
+    def connect_service(self, sock, service):
+        policy, allowed = self.engine.check_policy(sock, 'services', 'server', service)
+        print('##################################################')
+        print("policy:\n",json.dumps(policy, sort_keys=True, indent=4))
+        print('Callback: {}\n action: {}\n allowed: {}'.format('connect_service', service, allowed))
+        print('##################################################')
+        return allowed
+
+    def accept_service(self, sock, service):
+        policy, allowed = self.engine.check_policy(sock, 'services', 'client', service)
+        print('##################################################')
+        print("policy:\n",json.dumps(policy, sort_keys=True, indent=4))
+        print('Callback: {}\n action: {}\n allowed: {}'.format('accept_service', service, allowed))
+        print('##################################################')
+        return allowed

--- a/tools/rosgraph/src/rosgraph/validators.py
+++ b/tools/rosgraph/src/rosgraph/validators.py
@@ -65,22 +65,22 @@ class NameSpaceEngine(object):
             mask = ROLE_STRUCT[mode_name][role_name]['mask']
             info = (action_name, mask, 'self.node_stem', self.graph.graph_path)
             if self.graph_mode is GraphModes.enforce:
-                allowed, audit = self.graph.is_allowed(node_stem, role_name, action_name, mask)
+                allowed, audit = self.graph.is_allowed(node_stem, mode_name, action_name, mask)
                 flag = '*' if allowed else '!'
                 self._log_register(audit, flag, info)
                 return allowed
             elif self.graph_mode is GraphModes.train:
                 if self.graph.graph_path is not None:
-                    allowed, audit = self.graph.is_allowed(node_stem, role_name, action_name, mask)
+                    allowed, audit = self.graph.is_allowed(node_stem, mode_name, action_name, mask)
                     if not allowed:
-                        self.graph.add_allowed(node_stem, role_name, action_name, mask)
+                        self.graph.add_allowed(node_stem, mode_name, action_name, mask)
                         self.graph.save_graph()
                     flag = '*' if allowed else '+'
                     self._log_register((audit or not allowed), flag, info)
                 return True
             elif self.graph_mode is GraphModes.complain:
                 if self.graph.graph is not None:
-                    allowed, audit = self.graph.is_allowed(node_stem, role_name, action_name, mask)
+                    allowed, audit = self.graph.is_allowed(node_stem, mode_name, action_name, mask)
                     flag = '*' if allowed else '!'
                     self._log_register((audit or not allowed), flag, info)
                 else:
@@ -88,7 +88,7 @@ class NameSpaceEngine(object):
                 return True
             elif self.graph_mode is GraphModes.audit:
                 if self.graph.graph is not None:
-                    allowed, audit = self.graph.is_allowed(node_stem, role_name, action_name, mask)
+                    allowed, audit = self.graph.is_allowed(node_stem, mode_name, action_name, mask)
                     flag = '*' if allowed else '!'
                     self._log_register(True, flag, info)
                     return allowed
@@ -189,7 +189,7 @@ class NameSpaceMasterAPI(object):
     
     def registerService(self, context, f):
         def check_permitted(instance, caller_id, service, service_api, caller_api):
-            policy, allowed = self.engine.check_profile(context, 'topics', 'subscriber', service, caller_id)
+            policy, allowed = self.engine.check_profile(context, 'services', 'server', service, caller_id)
             if allowed:
                 return f(instance, caller_id, service, service_api, caller_api)
             else:
@@ -198,7 +198,7 @@ class NameSpaceMasterAPI(object):
 
     def lookupService(self, context, f):
         def check_permitted(instance, caller_id, service):
-            policy, allowed = self.engine.check_profile(context, 'topics', 'subscriber', service, caller_id)
+            policy, allowed = self.engine.check_profile(context, 'services', 'client', service, caller_id)
             if allowed:
                 return f(instance, caller_id, service)
             else:

--- a/tools/rosgraph/src/rosgraph/validators.py
+++ b/tools/rosgraph/src/rosgraph/validators.py
@@ -63,11 +63,11 @@ class NameSpaceEngine(object):
             from security import caller_id_to_node_stem
             node_stem = caller_id_to_node_stem(caller_id)
             mask = ROLE_STRUCT[mode_name][role_name]['mask']
-            info = (action_name, mask, self.node_stem, self.graph.graph_path)
+            info = (action_name, mask, 'self.node_stem', self.graph.graph_path)
             if self.graph_mode is GraphModes.enforce:
                 allowed, audit = self.graph.is_allowed(node_stem, role_name, action_name, mask)
                 flag = '*' if allowed else '!'
-                self.log_register(audit, flag, info)
+                self._log_register(audit, flag, info)
                 return allowed
             elif self.graph_mode is GraphModes.train:
                 if self.graph.graph_path is not None:
@@ -76,24 +76,24 @@ class NameSpaceEngine(object):
                         self.graph.add_allowed(node_stem, role_name, action_name, mask)
                         self.graph.save_graph()
                     flag = '*' if allowed else '+'
-                    self.log_register((audit or not allowed), flag, info)
+                    self._log_register((audit or not allowed), flag, info)
                 return True
             elif self.graph_mode is GraphModes.complain:
                 if self.graph.graph is not None:
                     allowed, audit = self.graph.is_allowed(node_stem, role_name, action_name, mask)
                     flag = '*' if allowed else '!'
-                    self.log_register((audit or not allowed), flag, info)
+                    self._log_register((audit or not allowed), flag, info)
                 else:
-                    self.log_register(True, '!', info)
+                    self._log_register(True, '!', info)
                 return True
             elif self.graph_mode is GraphModes.audit:
                 if self.graph.graph is not None:
                     allowed, audit = self.graph.is_allowed(node_stem, role_name, action_name, mask)
                     flag = '*' if allowed else '!'
-                    self.log_register(True, flag, info)
+                    self._log_register(True, flag, info)
                     return allowed
                 else:
-                    self.log_register(True, '', info)
+                    self._log_register(True, '', info)
                     return True
             else:
                 return False

--- a/tools/rosgraph/src/rosgraph/validators.py
+++ b/tools/rosgraph/src/rosgraph/validators.py
@@ -32,9 +32,9 @@ class PolicyInvalid(Exception):
 
 
 class NameSpaceEngine(object):
-    def __init__(self, node_name, _logger):
+    def __init__(self, node_name, logger):
         self.node_name = node_name
-        self._logger = _logger
+        self._logger = logger
         self._init_graph()
 
     def _init_graph(self):
@@ -164,10 +164,9 @@ class NameSpaceEngine(object):
 
 
 class NameSpaceMasterAPI(object):
-    
-    def __init__(self, engine, _logger):
-        self.engine = engine
-        self._logger = _logger
+    def __init__(self, engine, logger):
+        self._engine = engine
+        self._logger = logger
 
     ###############################################################################
     # EXTERNAL API
@@ -175,7 +174,7 @@ class NameSpaceMasterAPI(object):
     #TODO: How should external api calls be treated?
     # def shutdown(self, context, f):
     #     def check_permitted(instance, caller_id, msg):
-    #         policy, allowed = self.engine.check_profile(context, '?', '?', ?, caller_id)
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
     #         if allowed:
     #             return f(instance, caller_id, msg)
     #         else:
@@ -185,7 +184,7 @@ class NameSpaceMasterAPI(object):
     # 
     # def getUri(self, context, f):
     #     def check_permitted(instance, caller_id):
-    #         policy, allowed = self.engine.check_profile(context, '?', '?', ?, caller_id)
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
     #         if allowed:
     #             return f(instance, caller_id)
     #         else:
@@ -195,7 +194,7 @@ class NameSpaceMasterAPI(object):
     # 
     # def getPid(self, context, f):
     #     def check_permitted(instance, caller_id):
-    #         policy, allowed = self.engine.check_profile(context, '?', '?', ?, caller_id)
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
     #         if allowed:
     #             return f(instance, caller_id)
     #         else:
@@ -206,10 +205,10 @@ class NameSpaceMasterAPI(object):
     ################################################################
     # PARAMETER SERVER ROUTINES
 
-    #TODO add mutex locks in policy engine before enabling these high frequency calls 
+    #TODO add mutex locks in policy _engine before enabling these high frequency calls 
     # def deleteParam(self, context, f):
     #     def check_permitted(instance, caller_id, key):
-    #         policy, allowed = self.engine.check_profile(context, 'parameters', 'writer', key, caller_id)
+    #         policy, allowed = self._engine.check_profile(context, 'parameters', 'writer', key, caller_id)
     #         if allowed:
     #             return f(instance, caller_id, key)
     #         else:
@@ -218,7 +217,7 @@ class NameSpaceMasterAPI(object):
     # 
     # def setParam(self, context, f):
     #     def check_permitted(instance, caller_id, key, value):
-    #         policy, allowed = self.engine.check_profile(context, 'parameters', 'writer', key, caller_id)
+    #         policy, allowed = self._engine.check_profile(context, 'parameters', 'writer', key, caller_id)
     #         if allowed:
     #             return f(instance, caller_id, key, value)
     #         else:
@@ -227,7 +226,7 @@ class NameSpaceMasterAPI(object):
     # 
     # def getParam(self, context, f):
     #     def check_permitted(instance, caller_id, key):
-    #         policy, allowed = self.engine.check_profile(context, 'parameters', 'reader', key, caller_id)
+    #         policy, allowed = self._engine.check_profile(context, 'parameters', 'reader', key, caller_id)
     #         if allowed:
     #             return f(instance, caller_id, key)
     #         else:
@@ -236,7 +235,7 @@ class NameSpaceMasterAPI(object):
     # 
     # def searchParam(self, context, f):
     #     def check_permitted(instance, caller_id, key):
-    #         policy, allowed = self.engine.check_profile(context, 'parameters', 'reader', key, caller_id)
+    #         policy, allowed = self._engine.check_profile(context, 'parameters', 'reader', key, caller_id)
     #         if allowed:
     #             return f(instance, caller_id, key)
     #         else:
@@ -245,7 +244,7 @@ class NameSpaceMasterAPI(object):
     # 
     # def subscribeParam(self, context, f):
     #     def check_permitted(instance, caller_id, caller_api, key):
-    #         policy, allowed = self.engine.check_profile(context, 'parameters', 'reader', key, caller_id)
+    #         policy, allowed = self._engine.check_profile(context, 'parameters', 'reader', key, caller_id)
     #         if allowed:
     #             return f(instance, caller_id, caller_api, key)
     #         else:
@@ -255,17 +254,17 @@ class NameSpaceMasterAPI(object):
     # #TODO: Should one only be able to un{subscribe,register} using one's own caller_id?
     # def unsubscribeParam(self, context, f):
     #     def check_permitted(instance, caller_id, caller_api, key):
-    #         policy, allowed = self.engine.check_profile(context, 'parameters', 'reader', key, caller_id)
+    #         policy, allowed = self._engine.check_profile(context, 'parameters', 'reader', key, caller_id)
     #         if allowed:
     #             return f(instance, caller_id, caller_api, key)
     #         else:
     #             raise PolicyInvalid("ERROR: policy invalid for given action")
     #     return check_permitted
     # 
-    # #TODO: filter response through policy engine
+    # #TODO: filter response through policy _engine
     # # def hasParam(self, context, f):
     # #     def check_permitted(instance, caller_id, key):
-    # #         policy, allowed = self.engine.check_profile(context, 'parameters', 'reader', key, caller_id)
+    # #         policy, allowed = self._engine.check_profile(context, 'parameters', 'reader', key, caller_id)
     # #         if allowed:
     # #             return f(instance, caller_id, key)
     # #         else:
@@ -274,7 +273,7 @@ class NameSpaceMasterAPI(object):
     # # 
     # # def getParamNames(self, context, f):
     # #     def check_permitted(instance, caller_id):
-    # #         policy, allowed = self.engine.check_profile(context, 'parameters', 'reader', key, caller_id)
+    # #         policy, allowed = self._engine.check_profile(context, 'parameters', 'reader', key, caller_id)
     # #         if allowed:
     # #             return f(instance, caller_id)
     # #         else:
@@ -287,7 +286,7 @@ class NameSpaceMasterAPI(object):
     
     def registerService(self, context, f):
         def check_permitted(instance, caller_id, service, service_api, caller_api):
-            policy, allowed = self.engine.check_profile(context, 'services', 'server', service, caller_id)
+            policy, allowed = self._engine.check_profile(context, 'services', 'server', service, caller_id)
             if allowed:
                 return f(instance, caller_id, service, service_api, caller_api)
             else:
@@ -297,7 +296,7 @@ class NameSpaceMasterAPI(object):
     
     def lookupService(self, context, f):
         def check_permitted(instance, caller_id, service):
-            policy, allowed = self.engine.check_profile(context, 'services', 'client', service, caller_id)
+            policy, allowed = self._engine.check_profile(context, 'services', 'client', service, caller_id)
             if allowed:
                 return f(instance, caller_id, service)
             else:
@@ -307,7 +306,7 @@ class NameSpaceMasterAPI(object):
     
     def unregisterService(self, context, f):
         def check_permitted(instance, caller_id, service, service_api):
-            policy, allowed = self.engine.check_profile(context, 'services', 'server', service, caller_id)
+            policy, allowed = self._engine.check_profile(context, 'services', 'server', service, caller_id)
             if allowed:
                 return f(instance, caller_id, service, service_api)
             else:
@@ -321,7 +320,7 @@ class NameSpaceMasterAPI(object):
 
     def registerSubscriber(self, context, f):
         def check_permitted(instance, caller_id, topic, topic_type, caller_api):
-            policy, allowed = self.engine.check_profile(context, 'topics', 'subscriber', topic, caller_id)
+            policy, allowed = self._engine.check_profile(context, 'topics', 'subscriber', topic, caller_id)
             if allowed:
                 return f(instance, caller_id, topic, topic_type, caller_api)
             else:
@@ -330,7 +329,7 @@ class NameSpaceMasterAPI(object):
 
     def unregisterSubscriber(self, context, f):
         def check_permitted(instance, caller_id, topic, topic_type):
-            policy, allowed = self.engine.check_profile(context, 'topics', 'subscriber', topic, caller_id)
+            policy, allowed = self._engine.check_profile(context, 'topics', 'subscriber', topic, caller_id)
             if allowed:
                 return f(instance, caller_id, topic, topic_type)
             else:
@@ -339,7 +338,7 @@ class NameSpaceMasterAPI(object):
     
     def registerPublisher(self, context, f):
         def check_permitted(instance, caller_id, topic, topic_type, caller_api):
-            policy, allowed = self.engine.check_profile(context, 'topics', 'publisher', topic, caller_id)
+            policy, allowed = self._engine.check_profile(context, 'topics', 'publisher', topic, caller_id)
             if allowed:
                 return f(instance, caller_id, topic, topic_type, caller_api)
             else:
@@ -348,7 +347,7 @@ class NameSpaceMasterAPI(object):
     
     def unregisterPublisher(self, context, f):
         def check_permitted(instance, caller_id, topic, topic_type):
-            policy, allowed = self.engine.check_profile(context, 'topics', 'publisher', topic, caller_id)
+            policy, allowed = self._engine.check_profile(context, 'topics', 'publisher', topic, caller_id)
             if allowed:
                 return f(instance, caller_id, topic, topic_type)
             else:
@@ -362,7 +361,7 @@ class NameSpaceMasterAPI(object):
     #TODO: How should graph state api calls be treated?
     # def lookupNode(self, context, f):
     #     def check_permitted(instance, caller_id, node_name):
-    #         policy, allowed = self.engine.check_profile(context, '?', '?', ?, caller_id)
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
     #         if allowed:
     #             return f(instance, caller_id, node_name)
     #         else:
@@ -371,7 +370,7 @@ class NameSpaceMasterAPI(object):
     # 
     # def getPublishedTopics(self, context, f):
     #     def check_permitted(instance, caller_id, subgraph):
-    #         policy, allowed = self.engine.check_profile(context, '?', '?', ?, caller_id)
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
     #         if allowed:
     #             return f(instance, caller_id, subgraph)
     #         else:
@@ -380,7 +379,7 @@ class NameSpaceMasterAPI(object):
     # 
     # def getTopicTypes(self, context, f):
     #     def check_permitted(instance, caller_id):
-    #         policy, allowed = self.engine.check_profile(context, '?', '?', ?, caller_id)
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
     #         if allowed:
     #             return f(instance, caller_id)
     #         else:
@@ -389,7 +388,7 @@ class NameSpaceMasterAPI(object):
     # 
     # def getSystemState(self, context, f):
     #     def check_permitted(instance, caller_id):
-    #         policy, allowed = self.engine.check_profile(context, '?', '?', ?, caller_id)
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
     #         if allowed:
     #             return f(instance, caller_id)
     #         else:
@@ -398,10 +397,11 @@ class NameSpaceMasterAPI(object):
     
 
 class NameSpaceSlaveAPI(object):
-    def __init__(self, engine, _logger):
-        self.engine = engine
-        self._logger = _logger
+    def __init__(self, engine, logger):
+        self._engine = engine
+        self._logger = logger
 
+    
 
 class Transport(object):
 
@@ -418,12 +418,12 @@ class Transport(object):
         return True
 
 class NameSpaceTransport(Transport):
-    def __init__(self, engine, _logger):
-        self.engine = engine
-        self._logger = _logger
+    def __init__(self, engine, logger):
+        self._engine = engine
+        self._logger = logger
     
     def connect_topic(self, sock, topic):
-        policy, allowed = self.engine.check_policy(sock, 'topics', 'publisher', topic)
+        policy, allowed = self._engine.check_policy(sock, 'topics', 'publisher', topic)
         print('##################################################')
         print("policy:\n",json.dumps(policy, sort_keys=True, indent=4))
         print('Callback: {}\n action: {}\n allowed: {}'.format('connect_topic', topic, allowed))
@@ -431,7 +431,7 @@ class NameSpaceTransport(Transport):
         return allowed
 
     def accept_topic(self, sock, topic):
-        policy, allowed = self.engine.check_policy(sock, 'topics', 'subscriber', topic)
+        policy, allowed = self._engine.check_policy(sock, 'topics', 'subscriber', topic)
         print('##################################################')
         print("policy:\n",json.dumps(policy, sort_keys=True, indent=4))
         print('Callback: {}\n action: {}\n allowed: {}'.format('accept_topic', topic, allowed))
@@ -439,7 +439,7 @@ class NameSpaceTransport(Transport):
         return allowed
 
     def connect_service(self, sock, service):
-        policy, allowed = self.engine.check_policy(sock, 'services', 'server', service)
+        policy, allowed = self._engine.check_policy(sock, 'services', 'server', service)
         print('##################################################')
         print("policy:\n",json.dumps(policy, sort_keys=True, indent=4))
         print('Callback: {}\n action: {}\n allowed: {}'.format('connect_service', service, allowed))
@@ -447,7 +447,7 @@ class NameSpaceTransport(Transport):
         return allowed
 
     def accept_service(self, sock, service):
-        policy, allowed = self.engine.check_policy(sock, 'services', 'client', service)
+        policy, allowed = self._engine.check_policy(sock, 'services', 'client', service)
         print('##################################################')
         print("policy:\n",json.dumps(policy, sort_keys=True, indent=4))
         print('Callback: {}\n action: {}\n allowed: {}'.format('accept_service', service, allowed))

--- a/tools/rosgraph/src/rosgraph/validators.py
+++ b/tools/rosgraph/src/rosgraph/validators.py
@@ -414,6 +414,135 @@ class NameSpaceSlaveAPI(object):
         self._engine = engine
         self._logger = logger
 
+    ###############################################################################
+    # UNOFFICIAL/PYTHON-ONLY API
+
+    # TODO: How should unofficial api calls be treated?
+    # def getUri(self, context, f):
+    #     def check_permitted(instance, caller_id):
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    # 
+    #     return check_permitted
+    # 
+    # def getName(self, context, f):
+    #     def check_permitted(instance, caller_id):
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    # 
+    #     return check_permitted
+
+    ###############################################################################
+    # EXTERNAL API
+
+    # TODO: How should external api calls be treated?
+    # def getBusStats(self, context, f):
+    #     def check_permitted(instance, caller_id):
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    # 
+    #     return check_permitted
+    # 
+    # def getBusInfo(self, context, f):
+    #     def check_permitted(instance, caller_id):
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    # 
+    #     return check_permitted
+    # 
+    # def getMasterUri(self, context, f):
+    #     def check_permitted(instance, caller_id):
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    # 
+    #     return check_permitted
+    # 
+    # def shutdown(self, context, f):
+    #     def check_permitted(instance, caller_id, msg):
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id, msg)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    # 
+    #     return check_permitted
+    # 
+    # def getMasterUri(self, context, f):
+    #     def check_permitted(instance, caller_id):
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    # 
+    #     return check_permitted
+    # 
+    # def getPid(self, context, f):
+    #     def check_permitted(instance, caller_id):
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    # 
+    #     return check_permitted
+
+
+    ###############################################################################
+    # PUB/SUB APIS
+
+    # TODO: How should pub/sub api calls from master be treated?
+    # def getSubscriptions(self, context, f):
+    #     def check_permitted(instance, caller_id):
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    #     return check_permitted
+    # 
+    # def getPublications(self, context, f):
+    #     def check_permitted(instance, caller_id):
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    #     return check_permitted
+    # 
+    # def paramUpdate(self, context, f):
+    #     def check_permitted(instance, caller_id, parameter_key, parameter_value):
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id, parameter_key, parameter_value)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    #     return check_permitted
+    # 
+    # def publisherUpdate(self, context, f):
+    #     def check_permitted(instance, caller_id, topic, publishers):
+    #         policy, allowed = self._engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id, topic, publishers)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    #     return check_permitted
+
     def requestTopic(self, context, f):
         def check_permitted(instance, caller_id, topic, protocols):
             policy, allowed = self._engine.check_profile(context, 'topics', 'subscriber', topic, caller_id)

--- a/tools/rosgraph/src/rosgraph/validators.py
+++ b/tools/rosgraph/src/rosgraph/validators.py
@@ -168,12 +168,171 @@ class NameSpaceMasterAPI(object):
     def __init__(self, engine, _logger):
         self.engine = engine
         self._logger = _logger
+
+    ###############################################################################
+    # EXTERNAL API
     
+    #TODO: How should external api calls be treated?
+    # def shutdown(self, context, f):
+    #     def check_permitted(instance, caller_id, msg):
+    #         policy, allowed = self.engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id, msg)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    # 
+    #     return check_permitted
+    # 
+    # def getUri(self, context, f):
+    #     def check_permitted(instance, caller_id):
+    #         policy, allowed = self.engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    # 
+    #     return check_permitted
+    # 
+    # def getPid(self, context, f):
+    #     def check_permitted(instance, caller_id):
+    #         policy, allowed = self.engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    # 
+    #     return check_permitted
+
+    ################################################################
+    # PARAMETER SERVER ROUTINES
+
+    #TODO add mutex locks in policy engine before enabling these high frequency calls 
+    # def deleteParam(self, context, f):
+    #     def check_permitted(instance, caller_id, key):
+    #         policy, allowed = self.engine.check_profile(context, 'parameters', 'writer', key, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id, key)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    #     return check_permitted
+    # 
+    # def setParam(self, context, f):
+    #     def check_permitted(instance, caller_id, key, value):
+    #         policy, allowed = self.engine.check_profile(context, 'parameters', 'writer', key, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id, key, value)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    #     return check_permitted
+    # 
+    # def getParam(self, context, f):
+    #     def check_permitted(instance, caller_id, key):
+    #         policy, allowed = self.engine.check_profile(context, 'parameters', 'reader', key, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id, key)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    #     return check_permitted
+    # 
+    # def searchParam(self, context, f):
+    #     def check_permitted(instance, caller_id, key):
+    #         policy, allowed = self.engine.check_profile(context, 'parameters', 'reader', key, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id, key)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    #     return check_permitted
+    # 
+    # def subscribeParam(self, context, f):
+    #     def check_permitted(instance, caller_id, caller_api, key):
+    #         policy, allowed = self.engine.check_profile(context, 'parameters', 'reader', key, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id, caller_api, key)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    #     return check_permitted
+    # 
+    # #TODO: Should one only be able to un{subscribe,register} using one's own caller_id?
+    # def unsubscribeParam(self, context, f):
+    #     def check_permitted(instance, caller_id, caller_api, key):
+    #         policy, allowed = self.engine.check_profile(context, 'parameters', 'reader', key, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id, caller_api, key)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    #     return check_permitted
+    # 
+    # #TODO: filter response through policy engine
+    # # def hasParam(self, context, f):
+    # #     def check_permitted(instance, caller_id, key):
+    # #         policy, allowed = self.engine.check_profile(context, 'parameters', 'reader', key, caller_id)
+    # #         if allowed:
+    # #             return f(instance, caller_id, key)
+    # #         else:
+    # #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    # #     return check_permitted
+    # # 
+    # # def getParamNames(self, context, f):
+    # #     def check_permitted(instance, caller_id):
+    # #         policy, allowed = self.engine.check_profile(context, 'parameters', 'reader', key, caller_id)
+    # #         if allowed:
+    # #             return f(instance, caller_id)
+    # #         else:
+    # #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    # #     return check_permitted
+    
+    
+    ##################################################################################
+    # SERVICE PROVIDER
+    
+    def registerService(self, context, f):
+        def check_permitted(instance, caller_id, service, service_api, caller_api):
+            policy, allowed = self.engine.check_profile(context, 'services', 'server', service, caller_id)
+            if allowed:
+                return f(instance, caller_id, service, service_api, caller_api)
+            else:
+                raise PolicyInvalid("ERROR: policy invalid for given action")
+    
+        return check_permitted
+    
+    def lookupService(self, context, f):
+        def check_permitted(instance, caller_id, service):
+            policy, allowed = self.engine.check_profile(context, 'services', 'client', service, caller_id)
+            if allowed:
+                return f(instance, caller_id, service)
+            else:
+                raise PolicyInvalid("ERROR: policy invalid for given action")
+    
+        return check_permitted
+    
+    def unregisterService(self, context, f):
+        def check_permitted(instance, caller_id, service, service_api):
+            policy, allowed = self.engine.check_profile(context, 'services', 'server', service, caller_id)
+            if allowed:
+                return f(instance, caller_id, service, service_api)
+            else:
+                raise PolicyInvalid("ERROR: policy invalid for given action")
+    
+        return check_permitted
+
+
+    ##################################################################################
+    # PUBLISH/SUBSCRIBE
+
     def registerSubscriber(self, context, f):
         def check_permitted(instance, caller_id, topic, topic_type, caller_api):
             policy, allowed = self.engine.check_profile(context, 'topics', 'subscriber', topic, caller_id)
             if allowed:
                 return f(instance, caller_id, topic, topic_type, caller_api)
+            else:
+                raise PolicyInvalid("ERROR: policy invalid for given action")
+        return check_permitted
+
+    def unregisterSubscriber(self, context, f):
+        def check_permitted(instance, caller_id, topic, topic_type):
+            policy, allowed = self.engine.check_profile(context, 'topics', 'subscriber', topic, caller_id)
+            if allowed:
+                return f(instance, caller_id, topic, topic_type)
             else:
                 raise PolicyInvalid("ERROR: policy invalid for given action")
         return check_permitted
@@ -187,24 +346,56 @@ class NameSpaceMasterAPI(object):
                 raise PolicyInvalid("ERROR: policy invalid for given action")
         return check_permitted
     
-    def registerService(self, context, f):
-        def check_permitted(instance, caller_id, service, service_api, caller_api):
-            policy, allowed = self.engine.check_profile(context, 'services', 'server', service, caller_id)
+    def unregisterPublisher(self, context, f):
+        def check_permitted(instance, caller_id, topic, topic_type):
+            policy, allowed = self.engine.check_profile(context, 'topics', 'publisher', topic, caller_id)
             if allowed:
-                return f(instance, caller_id, service, service_api, caller_api)
+                return f(instance, caller_id, topic, topic_type)
             else:
                 raise PolicyInvalid("ERROR: policy invalid for given action")
         return check_permitted
 
-    def lookupService(self, context, f):
-        def check_permitted(instance, caller_id, service):
-            policy, allowed = self.engine.check_profile(context, 'services', 'client', service, caller_id)
-            if allowed:
-                return f(instance, caller_id, service)
-            else:
-                raise PolicyInvalid("ERROR: policy invalid for given action")
-        return check_permitted
 
+    ##################################################################################
+    # GRAPH STATE APIS
+    
+    #TODO: How should graph state api calls be treated?
+    # def lookupNode(self, context, f):
+    #     def check_permitted(instance, caller_id, node_name):
+    #         policy, allowed = self.engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id, node_name)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    #     return check_permitted
+    # 
+    # def getPublishedTopics(self, context, f):
+    #     def check_permitted(instance, caller_id, subgraph):
+    #         policy, allowed = self.engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id, subgraph)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    #     return check_permitted
+    # 
+    # def getTopicTypes(self, context, f):
+    #     def check_permitted(instance, caller_id):
+    #         policy, allowed = self.engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    #     return check_permitted
+    # 
+    # def getSystemState(self, context, f):
+    #     def check_permitted(instance, caller_id):
+    #         policy, allowed = self.engine.check_profile(context, '?', '?', ?, caller_id)
+    #         if allowed:
+    #             return f(instance, caller_id)
+    #         else:
+    #             raise PolicyInvalid("ERROR: policy invalid for given action")
+    #     return check_permitted
+    
 
 class NameSpaceSlaveAPI(object):
     def __init__(self, engine, _logger):

--- a/tools/rosgraph/src/rosgraph/validators.py
+++ b/tools/rosgraph/src/rosgraph/validators.py
@@ -414,7 +414,14 @@ class NameSpaceSlaveAPI(object):
         self._engine = engine
         self._logger = logger
 
-    
+    def requestTopic(self, context, f):
+        def check_permitted(instance, caller_id, topic, protocols):
+            policy, allowed = self._engine.check_profile(context, 'topics', 'subscriber', topic, caller_id)
+            if allowed:
+                return f(instance, caller_id, topic, protocols)
+            else:
+                raise PolicyInvalid("ERROR: policy invalid for given action")
+        return check_permitted
 
 class Transport(object):
 

--- a/tools/rosmaster/src/rosmaster/master_api.py
+++ b/tools/rosmaster/src/rosmaster/master_api.py
@@ -226,7 +226,7 @@ def publisher_update_task(api, topic, pub_uris):
     
     mloginfo("publisherUpdate[%s] -> %s", topic, api)
     #TODO: check return value for errors so we can unsubscribe if stale
-    security.get().xmlrpcapi(api, 'topic', 'publisher').publisherUpdate('/master', topic, pub_uris)
+    security.get().xmlrpcapi(api).publisherUpdate('/master', topic, pub_uris)
 
 def service_update_task(api, service, uri):
     """

--- a/tools/sros/CMakeLists.txt
+++ b/tools/sros/CMakeLists.txt
@@ -22,6 +22,8 @@ catkin_install_python(PROGRAMS scripts/sros
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 catkin_install_python(PROGRAMS scripts/sroscore
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+catkin_install_python(PROGRAMS scripts/sroslaunch
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 #if(CATKIN_ENABLE_TESTING)
 #  catkin_add_nosetests(test)

--- a/tools/sros/conf/keyserver_config.yaml
+++ b/tools/sros/conf/keyserver_config.yaml
@@ -90,8 +90,8 @@ keys: # reserved name in config for key configuration
       key: # leave blank to load private key from keystore
         key_type: rsa # {rsa,dsa,ec}; type of asymmetric cryptographic key to use https://cryptography.io/en/latest/hazmat/primitives/asymmetric/
         key_peram: 4096 # key length; commonly a power of 2, and usually no less than 2048 for security https://cryptography.io/en/latest/hazmat/primitives/asymmetric/rsa/?highlight=2048#generation
-      encryption_algorithm: BestAvailableEncryption # private key cipher; leave blank to save keyfile unencrypted https://cryptography.io/en/latest/hazmat/primitives/asymmetric/serialization/#serialization-encryption-types
-      password_env: SROS_ROOT_PASSWORD # environment variable to use acquire secret private key cipher password; leave to be propted to save keyfile unencrypted
+      encryption_algorithm: #BestAvailableEncryption # private key cipher; leave blank to save keyfile unencrypted https://cryptography.io/en/latest/hazmat/primitives/asymmetric/serialization/#serialization-encryption-types
+      password_env: #SROS_ROOT_PASSWORD # environment variable to use acquire secret private key cipher password; leave to be propted to save keyfile unencrypted
       fingerprint_algorithm: SHA256 # fingerprint method used for singing child certificate requests https://cryptography.io/en/latest/hazmat/primitives/cryptographic-hashes/?highlight=sha256#cryptography.hazmat.primitives.hashes.Hash
       cert: &default_cert # certificate specifications; leave blank to load public certificate from keystore
         subject: # change subject content accordingly for your use; must be somehow unique for each CA, https://cryptography.io/en/latest/x509/reference/#object-identifiers
@@ -108,7 +108,7 @@ keys: # reserved name in config for key configuration
       key:
         key_type: rsa
         key_peram: 2048 # overide key length inherited from root
-      password_env: SROS_MASTER_PASSWORD
+      password_env: #SROS_MASTER_PASSWORD
       cert:
         <<: *default_cert # forking from default cert, so include cert defaults
         subject: # change subject content accordingly for your use
@@ -126,7 +126,7 @@ keys: # reserved name in config for key configuration
       key: # overide key length inherited from master
         key_type: ec # computationally lighter for for signing
         key_peram: SECP384R1 # key curve; https://cryptography.io/en/latest/hazmat/primitives/asymmetric/ec/#elliptic-curves
-      password_env: SROS_NODE_PASSWORD
+      password_env: #SROS_NODE_PASSWORD
       cert:
         <<: *default_cert
         subject:
@@ -141,7 +141,7 @@ keys: # reserved name in config for key configuration
   utils: # reserved name for utility specific certificate configuration
     keyserver: &keyserver # reserved name for keyserver certificate configuration
       <<: *default
-      password_env: SROS_KEYSERVER_PASSWORD
+      password_env: #SROS_KEYSERVER_PASSWORD
       cert:
         <<: *default_cert # forking from root cert, so include cert defaults
         subject: # change subject content accordingly for your use

--- a/tools/sros/scripts/sroslaunch
+++ b/tools/sros/scripts/sroslaunch
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+import sros
+sros.sroslaunch_main()

--- a/tools/sros/setup.py
+++ b/tools/sros/setup.py
@@ -5,7 +5,7 @@ from catkin_pkg.python_setup import generate_distutils_setup
 d = generate_distutils_setup(
     packages=['sros'],
     package_dir={'': 'src'},
-    scripts=['scripts/sroscore', 'scripts/sros'],
+    scripts=['scripts/sroscore', 'scripts/sroslaunch', 'scripts/sros'],
     requires=[]
 )
 #requires=['genmsg', 'genpy', 'roslib', 'rospkg']

--- a/tools/sros/src/sros/__init__.py
+++ b/tools/sros/src/sros/__init__.py
@@ -4,8 +4,7 @@ import argparse
 import os
 import subprocess
 import sys
-import rosgraph.security as security
-import rosgraph.policy as policy
+from rosgraph.sros_consts import GraphModes
 import rosgraph.keyserver as keyserver
 import shutil
 import rospkg
@@ -27,7 +26,7 @@ class SroscoreParser(argparse.ArgumentParser):
             def __call__(self, parser, namespace, values, option_string=None):
                 for x in self.make_required:
                     x.required = True
-                if values not in policy.GraphModes:
+                if values not in GraphModes:
                     parser.error("Unknown MODE [{}] specified".format(values))
                 setattr(namespace, self.dest, values)
 

--- a/tools/sros/src/sros/__init__.py
+++ b/tools/sros/src/sros/__init__.py
@@ -140,6 +140,28 @@ def sroscore_main(argv = sys.argv):
     import roslaunch
     roslaunch.main(['roscore', '--core'] + roscore_argv[1:])
 
+def check_environ(name, default):
+    if name not in os.environ:
+        os.environ[name] = default
+
+def sroslaunch_main(argv = sys.argv):
+
+    check_environ(
+        'SROS_SECURITY',
+        'ssl')    
+    check_environ(
+        'SROS_POLICY',
+        'namespace')
+    check_environ(
+        'SROS_KEYSTORE_PATH',
+        os.path.join(os.path.expanduser('~'), '.ros', 'keys'))
+    check_environ(
+        'SROS_KEYSERVER_VERIFY',
+        'CERT_REQUIRED')
+    
+    import roslaunch
+    roslaunch.main(argv)
+    
 
 class SrosParser(argparse.ArgumentParser):
     """Argument parser class sros"""

--- a/tools/sros/src/sros/__init__.py
+++ b/tools/sros/src/sros/__init__.py
@@ -121,11 +121,15 @@ def sroscore_main(argv = sys.argv):
         keyserver_mode = os.environ['SROS_KEYSERVER_MODE']
         if not os.path.isfile(keyserver_config):
             keyserver_config_default = os.path.join(rospkg.get_etc_ros_dir(), 'keyserver_config.yaml')
+            if not os.path.exists(os.path.dirname(keyserver_config)):
+                os.makedirs(os.path.dirname(keyserver_config))
             shutil.copy(keyserver_config_default, keyserver_config)
 
         policy_config = os.path.abspath(os.environ['SROS_POLICY_CONFIG'])
         if not os.path.isfile(policy_config):
             policy_config_default = os.path.join(rospkg.get_etc_ros_dir(), 'policy_config.yaml')
+            if not os.path.exists(os.path.dirname(policy_config)):
+                os.makedirs(os.path.dirname(policy_config))
             shutil.copy(policy_config_default, policy_config)
         
         keyserver.fork_xmlrpc_keyserver(keyserver_config, keystore_path, keyserver_mode)


### PR DESCRIPTION
Adding api level policy based accsess control
-  breaking out policy evaluation into master_api, slave_api, transport, and policy engine
-  monkeypaches to xmlrpc server to gain peercert to dispatch request with context
-  wrapping master and slave api calls with policy validators
-  adding sroslaunch command to set default env if not already set
